### PR TITLE
Add support for IPv6 CIDR ranges as subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The configuration file has two mandatory settings:
 
 ## Advanced Configuration
 
-The server will assign each client which connects the next unused IP address from the range it is configured to serve.
+The server will assign each client which connects the next unused IP address from the range it is configured to serve. IPv6 CIDR ranges are supported.
 
 Because each client identifies itself with the hostname of the local system it is possible to map static IP addresses to any remote host, which is useful if you wish to setup DNS entries, etc.
 

--- a/cmd_client.go
+++ b/cmd_client.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -54,13 +55,24 @@ func (p *clientCmd) configureClient(dev *water.Interface, ip string, subnet stri
 	mtuStr := fmt.Sprintf("%d", mtu)
 	devStr := dev.Name()
 
+	// Parse the string as an IP
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return fmt.Errorf("Failed to parse %s as a valid IP", ip)
+	}
+
+	addr := ip + "/128"
+	if parsedIP.To4() != nil {
+		addr = ip + "/32"
+	}
+
 	//
 	// The commands we're going to execute
 	//
 	cmds := [][]string{
 		{"ip", "link", "set", "dev", devStr, "up"},
 		{"ip", "link", "set", "mtu", mtuStr, "dev", devStr},
-		{"ip", "addr", "add", ip + "/32", "dev", devStr},
+		{"ip", "addr", "add", addr, "dev", devStr},
 		{"ip", "route", "add", gateway, "dev", devStr},
 		{"ip", "route", "add", subnet, "via", gateway},
 	}

--- a/etc/server.cfg
+++ b/etc/server.cfg
@@ -28,7 +28,7 @@ key = Iequa[oogho5reiNgoo7ci4ruho~r#%fdsflj30-1l;alj1.>SDF£LK!
 ## Change the subnet from which we allocate IPs
 ##
 #
-# subnet = 10.137.248.0/24
+# subnet = 10.137.248.0/24 OR fde4:8dba:82e1:fefe::/64
 #
 
 


### PR DESCRIPTION
https://github.com/skx/simple-vpn/issues/12
A /64 subnet has 2^64 IP addresses which is way too many
to fit in-memory for the simple-vpn server. To add IPv6
support, we initialize the server with at-most 2^20 IPs
which translates to a /108 subnet. If we run out of IPs
in the /108, we expand the subnet to /107 and so on.